### PR TITLE
Add D435 & D435i meshes to get rid of realsense2_description dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
     image_transport
     camera_info_manager
     realsense_gazebo_plugin
-    realsense2_description
 )
 find_package(gazebo REQUIRED)
 
@@ -33,7 +32,6 @@ catkin_package(
         image_transport
         camera_info_manager
         realsense_gazebo_plugin
-        realsense2_description
 )
 
 ###########

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   <depend>image_transport</depend>
   <depend>camera_info_manager</depend>
   <depend>realsense_gazebo_plugin</depend>
-  <depend>realsense2_description</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/urdf/_d435.urdf.xacro
+++ b/urdf/_d435.urdf.xacro
@@ -82,9 +82,7 @@ aluminum peripherial evaluation case.
       <visual>
       <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
-          <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
-          <mesh filename="package://realsense2_description/meshes/d435.dae"/>
-          <!--<mesh filename="package://realsense2_description/meshes/d435/d435.dae"/>-->
+          <mesh filename="package://realsense_gazebo_description/meshes/d435.dae"/>
         </geometry>
         <material name="${name}_aluminum"/>
       </visual>

--- a/urdf/_d435i.urdf.xacro
+++ b/urdf/_d435i.urdf.xacro
@@ -86,9 +86,7 @@ aluminum peripherial evaluation case.
       <visual>
       <origin xyz="${d435i_cam_mount_from_center_offset} ${-d435i_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
         <geometry>
-          <!-- <box size="${d435i_cam_width} ${d435i_cam_height} ${d435i_cam_depth}"/> -->
-          <mesh filename="package://realsense2_description/meshes/d435.dae"/>
-          <!--<mesh filename="package://realsense2_description/meshes/d435/d435.dae"/>-->
+          <mesh filename="package://realsense_gazebo_description/meshes/d435.dae"/>
         </geometry>
         <material name="${name}_aluminum"/>
       </visual>


### PR DESCRIPTION
I added the D435 & D435i meshes directly to the package to get rid of the unnecessary dependency on realsense2_description.